### PR TITLE
Set get badge count android

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -11,7 +11,7 @@
 - [push.subscribe()](#pushsubscribetopic-successhandler-errorhandler)
 - [push.unsubscribe()](#pushunsubscribetopic-successhandler-errorhandler)
 - [push.setApplicationIconBadgeNumber() - iOS & Android only](#pushsetapplicationiconbadgenumbersuccesshandler-errorhandler-count---ios--android-only)
-- [push.getApplicationIconBadgeNumber() - iOS only](#pushgetapplicationiconbadgenumbersuccesshandler-errorhandler---ios-only)
+- [push.getApplicationIconBadgeNumber() - iOS & Android only](#pushgetapplicationiconbadgenumbersuccesshandler-errorhandler---ios--android-only)
 - [push.finish() - iOS only](#pushfinishsuccesshandler-errorhandler-id---ios-only)
 - [push.clearAllNotifications() - iOS & Android only](#pushclearallnotificationssuccesshandler-errorhandler---ios--android-only)
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -355,7 +355,7 @@ push.setApplicationIconBadgeNumber(function() {
 }, 2);
 ```
 
-## push.getApplicationIconBadgeNumber(successHandler, errorHandler) - iOS only
+## push.getApplicationIconBadgeNumber(successHandler, errorHandler) - iOS & Android only
 
 Get the current badge count visible when the app is not running
 

--- a/src/android/com/adobe/phonegap/push/PushConstants.java
+++ b/src/android/com/adobe/phonegap/push/PushConstants.java
@@ -59,6 +59,7 @@ public interface PushConstants {
     public static final String CONTENT_AVAILABLE = "content-available";
     public static final String TOPICS = "topics";
     public static final String SET_APPLICATION_ICON_BADGE_NUMBER = "setApplicationIconBadgeNumber";
+	public static final String GET_APPLICATION_ICON_BADGE_NUMBER = "getApplicationIconBadgeNumber";
     public static final String CLEAR_ALL_NOTIFICATIONS = "clearAllNotifications";
     public static final String VISIBILITY = "visibility";
     public static final String INLINE_REPLY = "inlineReply";

--- a/src/android/com/adobe/phonegap/push/PushPlugin.java
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.java
@@ -195,6 +195,18 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
                     callbackContext.success();
                 }
             });
+        } else if (GET_APPLICATION_ICON_BADGE_NUMBER.equals(action)) {
+            cordova.getThreadPool().execute(new Runnable() {
+                public void run() {
+                    Log.v(LOG_TAG, "getApplicationIconBadgeNumber");
+                    
+					int badgeCount = getApplicationIconBadgeNumber(getApplicationContext());
+					PluginResult pluginResult = new PluginResult(PluginResult.Status.OK, badgeCount);
+					pluginResult.setKeepCallback(true);
+					callbackContext.sendPluginResult(pluginResult);
+
+                }
+            });
         } else if (CLEAR_ALL_NOTIFICATIONS.equals(action)) {
             cordova.getThreadPool().execute(new Runnable() {
                 public void run() {
@@ -274,6 +286,18 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
         }
     }
 
+	/*
+     * Retrives badge count from SharedPreferences
+     */
+	public static int getApplicationIconBadgeNumber(Context context){
+        SharedPreferences settings = context.getSharedPreferences("badge", Context.MODE_PRIVATE);
+        int badge = settings.getInt("badge", 0);
+        return badge;
+    }
+	
+	/*
+     * Sets badge count on application icon and in SharedPreferences
+     */
     public static void setApplicationIconBadgeNumber(Context context, int badgeCount) {
         if (badgeCount > 0) {
             ShortcutBadger.applyCount(context, badgeCount);


### PR DESCRIPTION
Added getApplicationIconBadgeNumber method for Android

## Description
Added getApplicationIconBadgeNumber method for retrieving badge count in Android using SharedPreferences to store it

## Related Issue
[#1639](https://github.com/phonegap/phonegap-plugin-push/issues/1639)

## Motivation and Context
Made to add support to cordova-plugin-badge, which was unable to retrive badge number set by phonegap-plugin-push

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
